### PR TITLE
Make Spark a provided dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,22 +107,19 @@
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-core_2.11</artifactId>
 			<version>${spark.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-			</exclusions>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-sql_2.11</artifactId>
 			<version>${spark.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-mllib_2.11</artifactId>
 			<version>${spark.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.fommil.netlib</groupId>


### PR DESCRIPTION
If you are running with a prebuilt distro (e.g., on the cloud, or on a cluster running CDH), the spark-submit scripts will add the Spark JARs from the distro to the classpath. As such, it is preferable to not build Spark JARs into the user JAR you are providing (reduces JAR size, etc).